### PR TITLE
Extend the loading time of Cypress page

### DIFF
--- a/cypress/e2e/category.cy.js
+++ b/cypress/e2e/category.cy.js
@@ -36,7 +36,7 @@ describe('Category navigation test', () => {
       cy.contains('h2', category).should('be.visible').click()
       cy.url().should('include', '/' + category)
       cy.get('.joke-card').should('exist').and('be.visible') // Check joke card exist
-      cy.wait(500) // Allow page to fully load before navigating back
+      cy.wait(1000) // Allow page to fully load before navigating back
       cy.go('back') // Navigate back to test the next category
     }
   })

--- a/cypress/e2e/category.cy.js
+++ b/cypress/e2e/category.cy.js
@@ -33,10 +33,11 @@ describe('Category navigation test', () => {
   it('should navigate to the correct category', () => {
     cy.visit(Cypress.env('categories'))
     for (const category of categories) {
+      cy.wait(2000)
       cy.contains('h2', category).should('be.visible').click()
       cy.url().should('include', '/' + category)
       cy.get('.joke-card').should('exist').and('be.visible') // Check joke card exist
-      cy.wait(1000) // Allow page to fully load before navigating back
+      cy.wait(2000) // Allow page to fully load before navigating back
       cy.go('back') // Navigate back to test the next category
     }
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Increased wait times in category navigation tests to enhance stability when verifying joke card visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->